### PR TITLE
Set proper proj_home in ADSFlask instantiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+logs/
 parts/
 sdist/
 var/

--- a/adsmutils/__init__.py
+++ b/adsmutils/__init__.py
@@ -226,7 +226,8 @@ class ADSFlask(Flask):
         if 'proj_home' in kwargs:
             proj_home = kwargs.pop('proj_home')
         self._config = load_config(extra_frames=1, proj_home=proj_home)
-        proj_home = self._config.get('PROJ_HOME', None)
+        if not proj_home:
+            proj_home = self._config.get('PROJ_HOME', None)
 
         local_config = None
         if 'local_config' in kwargs and kwargs['local_config']:

--- a/adsmutils/__init__.py
+++ b/adsmutils/__init__.py
@@ -226,6 +226,7 @@ class ADSFlask(Flask):
         if 'proj_home' in kwargs:
             proj_home = kwargs.pop('proj_home')
         self._config = load_config(extra_frames=1, proj_home=proj_home)
+        proj_home = self._config.get('PROJ_HOME', None)
 
         local_config = None
         if 'local_config' in kwargs and kwargs['local_config']:


### PR DESCRIPTION
This way the proper `proj_home` is used when setting up logging