### PR TITLE
Default JSON format when LOG_STDOUT is set to True

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Set of common libraries used by ADS microservices.
 
 Class ADSFlask is to be used by all the microservice applications, where logging is setup automatically. 
-Note that if your microservice application requires logging to stdout in addition to the log file include
+Note that if your microservice application requires JSON logging to stdout in addition to the log file include
 
     LOG_STDOUT = True
 

--- a/adsmutils/__init__.py
+++ b/adsmutils/__init__.py
@@ -220,6 +220,7 @@ def setup_logging(name_, level=None, proj_home=None, attach_stdout=False):
 
     if attach_stdout:
         stdout = logging.StreamHandler(sys.stdout)
+        stdout.formatter = get_json_formatter()
         logging_instance.addHandler(stdout)
 
     return logging_instance


### PR DESCRIPTION
- Microservices stdout is captured by graylog which requires messages to be in JSON format to enable more advanced filtering. It seems reasonable to activate this formatting by default when the microservice has `LOG_STDOUT=True` in their config file.
- Key request fields will be added by default to the log (e.g., X-Original-Forwarded-For).
- Added a JSON log formatter specific for gunicorn, which output results as homogeneously as possible compared to the flask application.