### PR TITLE
update to use new version of python-discoverer

### DIFF
--- a/adsmutils/__init__.py
+++ b/adsmutils/__init__.py
@@ -513,8 +513,9 @@ class UTCDateTime(types.TypeDecorator):
     impl = TIMESTAMP(timezone=True)
     
     def process_bind_param(self, value, engine):
-        # when function is called by sqlalchemy it passes engine which we ignored
-        if isinstance(value, basestring):
+        # this function is called by sqlalchemy it passes engine which we ignored
+        # python2/3 compatible str and unicode check
+        if isinstance(value, (type('foo'), type(u'foo'))):
             return get_date(value).astimezone(utc_zone)
         elif value is not None:
             if value.tzname() is None:

--- a/adsmutils/tests/test_utils.py
+++ b/adsmutils/tests/test_utils.py
@@ -59,8 +59,10 @@ class TestAdsUtils(unittest.TestCase):
         with patch(u'adsmutils.ConcurrentRotatingFileHandler') as cloghandler:
             adsmutils.setup_logging(u'app')
             f = os.path.abspath(os.path.join(os.path.abspath(__file__), u'../../..'))
-            self.assertEqual(u"call(backupCount=10, encoding=u'UTF-8', filename=u'{filename}/logs/app.log', maxBytes=10485760, mode=u'a')".format(filename=f),
-                             str(cloghandler.call_args))
+            tmp = str(cloghandler.call_args)
+            tmp = tmp.replace("=u'", "='")   # remove unicode annotations in python 2
+            self.assertEqual("call(backupCount=10, encoding='UTF-8', filename='{filename}/logs/app.log', maxBytes=10485760, mode='a')".format(filename=f),
+                             tmp)
 
 
     def test_get_date(self):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,13 @@
-coverage==4.0.1
-coveralls==1.1.0
+coverage==4.5.4
+coveralls==1.8.2
 Flask-Testing==0.7.1
 httpretty==0.8.10
-mock==1.3.0
-pylint==1.9.5
-psycopg2==2.7.5
-pytest==2.8.2
-pytest-cov==2.2.0
-testing.postgresql==1.2.1
+mock==3.0.5
+psycopg2==2.7.5 ; python_version < '3.0'
+psycopg2==2.8.3 ; python_version > '3.0'
+pytest==2.8.2 ; python_version < '3.0'
+pytest==5.1.0; python_version > '3.0'
+pytest-cov==2.2.0 ; python_version < '3.0'
+pytest-cov==2.7.1 ; python_version > '3.0'
+testing.postgresql==1.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ DateTime==4.2.0
 Flask==0.12.4
 Flask-SQLAlchemy==2.3
 Flask-RESTful==0.3.6
-flask-discoverer==0.1.1
+flask-discoverer==0.1.4
 python-dateutil==2.6.0
 python-json-logger==0.1.9
 requests==2.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ DateTime==4.2.0
 Flask==0.12.4
 Flask-SQLAlchemy==2.3
 Flask-RESTful==0.3.6
-flask-discoverer==0.0.5
+flask-discoverer==0.1.1
 python-dateutil==2.6.0
 python-json-logger==0.1.9
 requests==2.19.1


### PR DESCRIPTION
use version of library compatible with python 2/3
added environemnt markers to dev-requirements.txt to support python 2/3 environments