### PR TITLE
Update Utils not to use setuptools greater than v58

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -15,7 +15,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade wheel setuptools pip
+        #python -m pip install --upgrade wheel setuptools pip
+        python -m pip install --upgrade wheel pip
         pip install -U -r requirements.txt
         pip install -U -r dev-requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ python-json-logger==0.1.11 ; python_version < '3.0'
 python-json-logger==2.0.1 ; python_version > '3.0'
 requests==2.25.1
 six>=1.15.0
-setuptools>=40.0.0
+setuptools>=40.0.0,<58.0.0
 SQLAlchemy==1.3.20


### PR DESCRIPTION
ConcurrentLogHandler is causing compability issues with newer versions of Python 3.8.11+ (last version was released in 2013). Moving to a fully compatible fork that has been maintained since then.